### PR TITLE
Add `WMClasses` command to see the application names through the busctl

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -17,6 +17,9 @@ class Xremap {
           <method name="WMClass">
             <arg type="s" direction="out" name="win"/>
           </method>
+          <method name="WMClasses">
+            <arg type="s" direction="out" name="win"/>
+          </method>
         </interface>
       </node>
     `;
@@ -43,6 +46,13 @@ class Xremap {
   WMClass() {
     const actor = global.get_window_actors().find(a=>a.meta_window.has_focus()===true);
     return actor && actor.get_meta_window().get_wm_class();
+  }
+
+  // To see the application names through the busctl
+  WMClasses() {
+    // Even if it makes the items in a list joined by "\n", dbus output escapes the new line characters.
+    // So this outputs JSON array string instead of the plain text for understandability.
+    return JSON.stringify([...new Set(global.get_window_actors().map(a => a.get_meta_window().get_wm_class()))]);
   }
 }
 


### PR DESCRIPTION
[k0kubun/xremap](https://github.com/k0kubun/xremap) readme says the following command helps to get the application names in the window system:

    busctl --user call org.gnome.Shell /com/k0kubun/Xremap com.k0kubun.Xremap WMClass

but `WMClass` method only shows the current window-focused application name, so it needs a tiny trick to get another window's app name; like doing `sleep 2; busctl --user call org.gnome.Shell /com/k0kubun/Xremap com.k0kubun.Xremap WMClass` and changing the focus onto another window while it's sleeping.

So this commit introduces a new method `WMClasses` to show all application names in the window system through the busctl tool.

Usage example:

    $ busctl --user call org.gnome.Shell /com/k0kubun/Xremap com.k0kubun.Xremap WMClasses
    s "[\"discord\",\"Slack\",\"Google-chrome\",\"gnome-terminal-server\",\"Gnome-shell\"]"