### PR TITLE
Add GNOME Shell 43 to compatibility list

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,8 @@
     "3.38",
     "40",
     "41",
-    "42"
+    "42",
+    "43"
   ],
   "url" : "https://github.com/xremap/xremap-gnome",
   "uuid": "xremap@k0kubun.com",


### PR DESCRIPTION
Just tested the extension on GNOME 43 and it works fine :smile: 