### PR TITLE
Add GNOME Shell 44 to compatibility list

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,8 @@
     "40",
     "41",
     "42",
-    "43"
+    "43",
+    "44"
   ],
   "url" : "https://github.com/xremap/xremap-gnome",
   "uuid": "xremap@k0kubun.com",


### PR DESCRIPTION
Just tested the extension on GNOME 44 and it works fine :+1: 