### PR TITLE
Porting to GNOME 45

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,12 +1,10 @@
 // Copyright (C) 2022 Takashi Kokubun
 // Licence: GPLv2+
 
-const { Gio } = imports.gi;
+import Gio from 'gi://Gio'
+import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 
-class Xremap {
-  constructor() {
-  }
-
+export default class Xremap extends Extension {
   enable() {
     const dbus_object = `
       <node>
@@ -56,6 +54,3 @@ class Xremap {
   }
 }
 
-function init() {
-  return new Xremap();
-}

--- a/extension.js
+++ b/extension.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2022 Takashi Kokubun
 // Licence: GPLv2+
 
-import Gio from 'gi://Gio'
+import Gio from 'gi://Gio';
 import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 
 export default class Xremap extends Extension {
@@ -32,17 +32,24 @@ export default class Xremap extends Extension {
   }
 
   ActiveWindow() {
-    const actor = global.get_window_actors().find(a=>a.meta_window.has_focus()===true);
+    const actor = global
+      .get_window_actors()
+      .find((a) => a.meta_window.has_focus() === true);
     if (actor) {
       const w = actor.get_meta_window();
-      return JSON.stringify({ wm_class: w.get_wm_class(), title: w.get_title() });
+      return JSON.stringify({
+        wm_class: w.get_wm_class(),
+        title: w.get_title(),
+      });
     } else {
       return '{}';
     }
   }
 
   WMClass() {
-    const actor = global.get_window_actors().find(a=>a.meta_window.has_focus()===true);
+    const actor = global
+      .get_window_actors()
+      .find((a) => a.meta_window.has_focus() === true);
     return actor && actor.get_meta_window().get_wm_class();
   }
 
@@ -50,7 +57,12 @@ export default class Xremap extends Extension {
   WMClasses() {
     // Even if it makes the items in a list joined by "\n", dbus output escapes the new line characters.
     // So this outputs JSON array string instead of the plain text for understandability.
-    return JSON.stringify([...new Set(global.get_window_actors().map(a => a.get_meta_window().get_wm_class()))]);
+    return JSON.stringify([
+      ...new Set(
+        global
+          .get_window_actors()
+          .map((a) => a.get_meta_window().get_wm_class()),
+      ),
+    ]);
   }
 }
-

--- a/metadata.json
+++ b/metadata.json
@@ -2,13 +2,7 @@
   "name": "Xremap",
   "description": "Allow xremap to fetch the focused app name using D-Bus",
   "shell-version" : [
-    "3.36",
-    "3.38",
-    "40",
-    "41",
-    "42",
-    "43",
-    "44"
+    "45"
   ],
   "url" : "https://github.com/xremap/xremap-gnome",
   "uuid": "xremap@k0kubun.com",


### PR DESCRIPTION
GNOME 45 landed so I guess it's time for the usual upgrade :smile: 

This time it was a little bit different tho, because GNOME 45 disrupted a little bit the usual behavior of the extensions:

- I had to replace the `init()` function with an `export default` of the whole class;
- Import paths are changing from now on switching to `gi://` also for Gio;
- I took the chance to run `prettier --single-quote` on the code and apply a little bit of formatting. If you don't like it I can drop the commit.

I did all of this following [the documentation](https://gjs.guide/extensions/upgrading/gnome-shell-45.html), so now the `metadata.json` just has `45` in the array of compatible versions.