### PR TITLE
Update metadata.json for GNOME 47

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,8 @@
   "description": "Allow xremap to fetch the focused app name using D-Bus",
   "shell-version" : [
     "45",
-    "46"
+    "46",
+    "47"
   ],
   "url" : "https://github.com/xremap/xremap-gnome",
   "uuid": "xremap@k0kubun.com",


### PR DESCRIPTION
@k0kubun 

After testing on Fedora Rawhide with the GNOME 47 beta, there was no apparent issue with the Xremap GNOME shell extension. Only required updating the list of compatible shell versions. 
