### PR TITLE
Update for GNOME 48, version bump

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,5 +9,5 @@
   ],
   "url" : "https://github.com/xremap/xremap-gnome",
   "uuid": "xremap@k0kubun.com",
-  "version" : 8
+  "version" : 9
 }

--- a/metadata.json
+++ b/metadata.json
@@ -4,9 +4,10 @@
   "shell-version" : [
     "45",
     "46",
-    "47"
+    "47",
+    "48"
   ],
   "url" : "https://github.com/xremap/xremap-gnome",
   "uuid": "xremap@k0kubun.com",
-  "version" : 7
+  "version" : 8
 }


### PR DESCRIPTION
@k0kubun 

No problem observed in GNOME 48 on Fedora Rawhide, after manually adding "48" to shell versions list. 

Fedora 42 with GNOME 48 should be available as a beta release shortly. Time to update the extension again. 
