### PR TITLE
Improve security model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.zip
+/schemas/gschemas.compiled

--- a/extension.js
+++ b/extension.js
@@ -2,6 +2,7 @@
 // Licence: GPLv2+
 
 import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
 import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 
 export default class Xremap extends Extension {
@@ -23,9 +24,24 @@ export default class Xremap extends Extension {
     `;
     this.dbus = Gio.DBusExportedObject.wrapJSObject(dbus_object, this);
     this.dbus.export(Gio.DBus.session, '/com/k0kubun/Xremap');
+
+    this._settings = this.getSettings();
+    this._socketPath = this._settings.get_string('socket-path');
+    this._socketService = null;
+    this._isLocked = false;
+    this._settingsChangedId = this._settings.connect(
+      'changed::socket-path', () => { this._onSocketPathChanged(); });
+    this._startSocketServer();
   }
 
   disable() {
+    this._stopSocketServer();
+    if (this._settingsChangedId) {
+      this._settings.disconnect(this._settingsChangedId);
+    }
+    this._settingsChangedId = null;
+    this._settings = null;
+
     this.dbus.flush();
     this.dbus.unexport();
     delete this.dbus;
@@ -65,4 +81,189 @@ export default class Xremap extends Extension {
       ),
     ]);
   }
+
+  _startSocketServer() {
+    if (this._socketService || this._isLocked || !this._socketPath) {
+      return;
+    }
+
+    try {
+      const socketDir = GLib.path_get_dirname(this._socketPath);
+      const dirFile = Gio.File.new_for_path(socketDir);
+      if (!dirFile.query_exists(null)) {
+        this._log(`Skipping socket server. Socket directory ${socketDir} does not exist.`);
+        return;
+      }
+      const socketFile = Gio.File.new_for_path(this._socketPath);
+      if (this._isSocket(socketFile)) {
+        try {
+          socketFile.delete(null);
+        } catch (e) {
+          this._log(`Skipping socket server. Cannot remove stale socket: ${e.message}`);
+          return;
+        }
+      } else if (socketFile.query_exists(null)) {
+        this._log(`Skipping socket server. Socket file has wrong type.`);
+        return;
+      }
+
+      this._socketService = new Gio.SocketService();
+      this._socketService.add_address(
+        Gio.UnixSocketAddress.new(this._socketPath),
+        Gio.SocketType.STREAM,
+        Gio.SocketProtocol.DEFAULT,
+        null
+      );
+      this._socketService.connect('incoming', this._handleConnection);
+      this._socketService.start();
+      this._log(`Socket server listening on ${this._socketPath}`);
+
+      try {
+        GLib.chmod(this._socketPath, 0o660);
+      } catch (e) {
+        this._log(`Cannot set socket permissions: ${e.message}`);
+      }
+    } catch (e) {
+      this._log(`Cannot start socket server: ${e.message}`);
+      this._socketService = null;
+    }
+  }
+
+  _stopSocketServer() {
+    if (this._socketService) {
+      this._socketService.stop();
+      this._socketService.close();
+      this._socketService = null;
+      try {
+        const socketFile = Gio.File.new_for_path(this._socketPath);
+        if (this._isSocket(socketFile)) {
+          socketFile.delete(null);
+          this._log(`Removed socket file: ${this._socketPath}`);
+        }
+      } catch (e) {
+        this._log(`Failed to remove socket file: ${e.message}`);
+      }
+    }
+  }
+
+  _handleConnection = (service, connection) => {
+    try {
+      const inputStream = connection.get_input_stream();
+      const outputStream = connection.get_output_stream();
+      const dataInputStream = new Gio.DataInputStream({base_stream: inputStream});
+      const [line] = dataInputStream.read_line_utf8(null);
+      if (line) {
+        const response = this._processCommand(line, outputStream);
+        if (response) {
+          outputStream.write(JSON.stringify(response) + '\n', null);
+          outputStream.flush(null);
+        }
+      }
+    } catch (e) {
+      this._log(`Connection error: ${e.message}`);
+    } finally {
+      connection.close(null);
+    }
+    return true;
+  }
+
+  _processCommand(command, outputStream) {
+    try {
+      const cmd = JSON.parse(command);
+      if (cmd === 'ActiveWindow') {
+        return this._getActiveWindow() || {};
+      }
+      if (cmd === 'Windows') {
+        // works with Niri variant of xremap
+        return this._getWindows();
+      }
+      if (typeof cmd === 'object' && cmd.Run) {
+        return this._run(cmd.Run);
+      }
+      this._log(`Unknown command: ${command}`);
+      return { Error: 'Unknown command' };
+    } catch (e) {
+      this._log(`Command error: ${e.message}`);
+      return { Error: e.message };
+    }
+  }
+
+  _getActiveWindow() {
+    const actor = global
+      .get_window_actors()
+      .find((a) => a.meta_window.has_focus() === true);
+    if (actor) {
+      const w = actor.get_meta_window();
+      return { wm_class: w.get_wm_class() || '', title: w.get_title() || '' };
+    }
+    return null;
+  }
+
+  _getWindows() {
+    const windows = [];
+    const window = this._getActiveWindow();
+    if (window) {
+      windows.push({
+        ...BASE_NIRI_WINDOW,
+        app_id: window.wm_class,
+        title: window.title,
+      });
+    }
+    return { Ok: { Windows: windows } };
+  }
+
+  _run(command) {
+    try {
+      let proc = new Gio.Subprocess({
+          argv: command,
+          flags: GLib.SpawnFlags.SEARCH_PATH
+               | GLib.SpawnFlags.STDIN_TO_DEV_NULL
+               | GLib.SpawnFlags.STDOUT_TO_DEV_NULL
+               | GLib.SpawnFlags.STDERR_TO_DEV_NULL
+      });
+      proc.init(null);
+      proc.wait_check_async(null, (source, result) => {
+        try {
+          source.wait_check_finish(result);
+        } catch (e) {
+          this._log(`${JSON.stringify(command)} error: ${e.message}`);
+        }
+      });
+    } catch (e) {
+      this._log(`Cannot run ${JSON.stringify(command)}: ${e.message}`);
+    }
+    return "Ok";
+  }
+
+  _onSocketPathChanged() {
+    const path = this._settings.get_string('socket-path');
+    if (path !== this._socketPath) {
+      this._stopSocketServer();
+      this._socketPath = path;
+      this._startSocketServer();
+    }
+  }
+
+  _isSocket(file) {
+    return file.query_file_type('', null) === Gio.FileType.SPECIAL;
+  }
+
+  _log(message) {
+    log(`[Xremap] ${message}`);
+  }
 }
+
+const BASE_NIRI_WINDOW = {
+  id: 1,
+  app_id: '',
+  title: '',
+  workspace_id: 1,
+  is_focused: true,
+  is_floating: false,
+  is_urgent: false,
+  layout: {
+    tile_size: [0, 0],
+    window_size: [0, 0],
+    window_offset_in_tile: [0, 0],
+  },
+};

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Xremap",
-  "description": "Allow xremap to fetch the focused app name using D-Bus",
+  "description": "Allow xremap to fetch the focused app name using D-Bus or local socket.",
   "shell-version" : [
     "45",
     "46",
@@ -8,7 +8,8 @@
     "48",
     "49"
   ],
+  "settings-schema": "org.gnome.shell.extensions.xremap",
   "url" : "https://github.com/xremap/xremap-gnome",
   "uuid": "xremap@k0kubun.com",
-  "version" : 10
+  "version" : 11
 }

--- a/package.sh
+++ b/package.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-zip extension.zip extension.js metadata.json
+glib-compile-schemas --strict schemas/
+zip extension.zip extension.js metadata.json prefs.js schemas/*

--- a/prefs.js
+++ b/prefs.js
@@ -1,0 +1,50 @@
+// Licence: GPLv2+
+
+import Adw from 'gi://Adw';
+import Gtk from 'gi://Gtk';
+import { ExtensionPreferences } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+
+export default class XremapPreferences extends ExtensionPreferences {
+  fillPreferencesWindow(window) {
+    const settings = this.getSettings();
+    const page = new Adw.PreferencesPage({
+      title: 'General',
+      icon_name: 'dialog-information-symbolic',
+    });
+    window.add(page);
+
+    const group = new Adw.PreferencesGroup({
+      title: 'Socket Configuration',
+      description: 'Configure the Unix socket for xremap communication',
+    });
+    page.add(group);
+
+    const socketRow = new Adw.EntryRow({
+      title: 'Socket Path',
+      text: settings.get_string('socket-path'),
+    });
+    socketRow.set_show_apply_button(true);
+    socketRow.connect('apply', () => {
+      const path = socketRow.get_text();
+      if (path !== settings.get_string('socket-path')) {
+        settings.set_string('socket-path', path);
+      }
+    });
+    group.add(socketRow);
+
+    const infoGroup = new Adw.PreferencesGroup({title: 'Information'});
+    page.add(infoGroup);
+    const infoBox = new Gtk.Box({orientation: Gtk.Orientation.VERTICAL});
+    infoBox.append(new Gtk.Label({
+      label: 'The directory must exist and be writable by the gnome session ' +
+             'user, otherwise the socket server will not run.',
+      wrap: true,
+      xalign: 0,
+      margin_top: 12,
+      margin_bottom: 12,
+      margin_start: 12,
+      margin_end: 12,
+    }));
+    infoGroup.add(new Adw.PreferencesRow({child: infoBox}));
+  }
+}

--- a/schemas/org.gnome.shell.extensions.xremap.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.xremap.gschema.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+  <schema id="org.gnome.shell.extensions.xremap" path="/org/gnome/shell/extensions/xremap/">
+    <key name="socket-path" type="s">
+      <default>'/run/xremap/gnome.sock'</default>
+      <summary>Unix socket path</summary>
+      <description>Path to the Unix socket for xremap communication. The directory must exist and be writable by the gnome session user.</description>
+    </key>
+  </schema>
+</schemalist>


### PR DESCRIPTION
This introduces a Unix socket-based communication method for xremap in GNOME, addressing limitations with the current DBUS implementation. This change allows xremap to query the active window when running as a separate user, improving flexibility and security.

Xremap GNOME now has these features as of [v0.14.6](https://github.com/xremap/xremap/pull/805):

- A simple socket protocol to fetch ActiveWindow.
- Re-check for socket existence to prevent permanent 'unsupported' state: GNOME (supported: false).
- Delegate command execution to the GNOME extension instead of launching subprocesses directly.

The following is not yet done:

- Improve multi-user support: Use a separate socket for each user so permissions can be tightened to prevent a user from hijacking another user's socket.

## System configuration to run xremap as a dedicated system user

First, for each user account that will use xremap mappings, install the [xremap-gnome extension](https://extensions.gnome.org/extension/5060/xremap/) with socket support (v11 or later). This can be done system-wide by installing the extension in `/usr/share/gnome-shell/extensions/xremap@k0kubun.com`.

### Create xremap configuration file: _/etc/xremap/config.yml_

Once created, ensure the file has proper ownership and permissions:

```sh
sudo chown root:root /etc/xremap/config.yml
sudo chmod 644 /etc/xremap/config.yml
```

### Create _xremap_ user and group

```sh
sudo groupadd xremap
sudo useradd --system --no-create-home --shell=/bin/false -g xremap --groups=input xremap
```

WARNING: Other users should NOT be members of the _xremap_ group since members of this group can read and write to xremap-gnome sockets created by any user, which allows arbitrary command execution as the user owning the socket.

### Install the GNOME variant of xremap v0.14.6 or later

Use the best [installation procedure](https://github.com/xremap/xremap?tab=readme-ov-file#Installation) for your system.

### Create systemd unit files

_/etc/systemd/system/xremap.service_
```ini
[Unit]
Description=Xremap keyboard mapper

[Service]
Type=simple
ExecStart=/usr/local/bin/xremap --watch=config,device /etc/xremap/config.yml
Environment=GNOME_SOCKET=/run/xremap/gnome.sock
User=xremap
Group=xremap
RuntimeDirectory=xremap
RuntimeDirectoryMode=2773
# RuntimeDirectoryMode=2773 vulnerability: any user can remove/replace the
# socket (denial of service). This is less critical than adding users to the
# 'input' group, which would allow any user process to log key events. However,
# be aware of potential abuses:
#
# - Information about when a user is typing could be leaked.
# - Information could be leaked if a {"Run": ["command"]} is sent over the
#   socket by xremap and xremap is configured with sensitive commands. This
#   is not usually an issue since the configuration file usually has world
#   read permissions.
# - A maliciously created socket could publish incorrect active window details,
#   which could activate unwanted key mappings.
#
RuntimeDirectoryPreserve=restart
SupplementaryGroups=input
Restart=always

# Hardening
NoExecPaths=/
ExecPaths=/usr
ReadWritePaths=/run/xremap /dev/input /dev/uinput
NoNewPrivileges=yes
PrivateTmp=yes
ProtectSystem=strict
ProtectHome=yes
ProtectKernelModules=yes
ProtectKernelTunables=yes
ProtectControlGroups=yes

[Install]
WantedBy=multi-user.target
```

### Enable systemd units

```sh
sudo systemctl enable --now xremap.service
```

Restart your user session (logout) to reload the GNOME extension.

----

Tested on Fedora 42 (GNOME 48) and Fedora 43 (GNOME 49).

Use this command to monitor logs for xremap-related issues:
```sh
journalctl -f --since="10 min ago" | grep -i xremap
```