### PR TITLE
Add socket feature to xremap installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ GNOME Shell extension for xremap
 The GNOME version of [xremap](https://github.com/k0kubun/xremap), a Linux key remapper,
 relies on this GNOME Shell extension to fetch the active application name.
 
-So you need to install this if you want to use [xremap](https://github.com/k0kubun/xremap) with `--features gnome`.
+So you need to install this if you want to use [xremap](https://github.com/k0kubun/xremap) with `--features gnome` or with `--features socket`.
 
 ## Installation
 


### PR DESCRIPTION
Tiny update to README to include 'socket' feature for xremap.